### PR TITLE
Setup elasticsearch from lua not curl and only run the required Elasticsearch docker container

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -62,13 +62,13 @@ jobs:
           ES_TEST_PORT: 19200
           ELASTIC_CREDS: -u elastic:changeme
           PROTOCOL: https
-        run: bash -x tests/gh_actions/setup_elastic.sh && cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
+        run: cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
       - name: run the tests for opensearch2
         if: ${{ matrix.elastic == 'os2' }}
         env:
           ES_TEST_PORT: 29200
-        run: bash -x tests/gh_actions/setup_elastic.sh && cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
+        run: cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
       - name: run the tests for el7
         if: ${{ matrix.elastic == 'el7' }}
-        run: bash -x tests/gh_actions/setup_elastic.sh && cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
+        run: cd tests && luarocks path >lpath.sh && source lpath.sh && lua run-tests.lua
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -44,7 +44,7 @@ jobs:
       - name: install docker-compose
         run: curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > docker-compose && chmod +x docker-compose && sudo mv docker-compose /usr/local/bin
       - name: run elasticsearch
-        run: cd docker && docker-compose -f create-certs.yml up && docker-compose up -d && cd ..
+        run: cd docker && docker-compose -f create-certs.yml up && cp docker-compose.yml.${{ matrix.elastic }} docker-compose.yml && docker-compose up -d && cd ..
       - name: setup test environment
         env:
           LUA: ${{ matrix.lua }}

--- a/docker/docker-compose.yml.el7
+++ b/docker/docker-compose.yml.el7
@@ -1,0 +1,24 @@
+version: '2.2'
+
+services:
+  es01:
+    container_name: es01
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+    environment:
+      - node.name=es01
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.license.self_generated.type=trial
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+    healthcheck:
+      test: curl -s https://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  
+  wait_until_ready:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+    command: /usr/bin/true
+    depends_on: {"es01": {"condition": "service_healthy"}}

--- a/docker/docker-compose.yml.el8
+++ b/docker/docker-compose.yml.el8
@@ -1,16 +1,6 @@
 version: '2.2'
 
 services:
-  es01:
-    container_name: es01
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.2
-    environment:
-      - node.name=es01
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - xpack.license.self_generated.type=trial 
-    ports:
-      - 9200:9200
-
   es02:
     container_name: es02
     image: docker.elastic.co/elasticsearch/elasticsearch:8.2.2
@@ -18,8 +8,8 @@ services:
       - node.name=es02
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - discovery.type=single-node
       - xpack.license.self_generated.type=trial
+      - discovery.type=single-node
       - xpack.security.enabled=true
       - xpack.security.http.ssl.enabled=true
       - xpack.security.http.ssl.key=$CERTS_DIR/es02/es02.key
@@ -30,7 +20,8 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
       - xpack.security.transport.ssl.certificate=$CERTS_DIR/es02/es02.crt
       - xpack.security.transport.ssl.key=$CERTS_DIR/es02/es02.key
-    volumes: ['esdata_02:/usr/share/elasticsearch/data', './certs:$CERTS_DIR']
+    #volumes: ['esdata_02:/usr/share/elasticsearch/data', './certs:$CERTS_DIR']
+    volumes: ['./certs:$CERTS_DIR']
     ports:
       - 19200:9200
     healthcheck:

--- a/docker/docker-compose.yml.os2
+++ b/docker/docker-compose.yml.os2
@@ -1,0 +1,32 @@
+version: '2.2'
+
+services:
+  os01:
+    image: opensearchproject/opensearch:2.0.0
+    container_name: os01
+    environment:
+      - node.name=os01
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    ports:
+      - 29200:9200
+    healthcheck:
+      test: curl -s https://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  
+  wait_until_ready:
+    image: opensearchproject/opensearch:2.0.0
+    command: /usr/bin/true
+    depends_on: {"os01": {"condition": "service_healthy"}}
+

--- a/tests/run-tests.lua
+++ b/tests/run-tests.lua
@@ -16,7 +16,13 @@ function runIntegrationTests()
   require "integration.init"
 end
 
+function runSetupElastic()
+   local setup = require "setup"
+   setup.init()
+end
+
 -- Running all tests for now
+runSetupElastic()
 runUnitTests()
 runIntegrationTests()
 

--- a/tests/setup.lua
+++ b/tests/setup.lua
@@ -35,16 +35,28 @@ function setup.init()
    local res, err = client.indices:create{
       index = TEST_INDEX
    }
+   if res == nil
+   then
+      print("Could not create index " .. TEST_INDEX .. " [" .. err .. "]" .. "\n")
+   end
       
-   res, status = client.indices:create{
+   res, err = client.indices:create{
       index = REINDEX_INDEX1
    }
+   if res == nil
+   then
+      print("Could not create index " .. REINDEX_INDEX1  .. " [" .. err .. "]" .. "\n")
+   end
 
-   res, status = client.indices:create{
+   res, err = client.indices:create{
       index = REINDEX_INDEX2
    }
+   if res == nil
+   then
+      print("Could not create index " .. REINDEX_INDEX2  .. " [" .. err .. "]" .. "\n")
+   end
 
-   res, status = client.indices:putSettings{
+   res, err = client.indices:putSettings{
       index = _all,
       body = {
          index = {
@@ -56,6 +68,10 @@ function setup.init()
          }
       }
    }
+   if res == nil
+   then
+      print("Could not change mapping fields limit [" .. err .. "]" .. "\n")
+   end
 end
 
 return setup;

--- a/tests/setup.lua
+++ b/tests/setup.lua
@@ -1,0 +1,61 @@
+-- Importing modules
+local elasticsearch = require "elasticsearch"
+
+local _ENV = lunit.TEST_CASE "tests.setup"
+
+-- Declaring module
+local setup = {}
+
+local protocol = os.getenv("ES_TEST_PROTOCOL")
+if protocol == nil then protocol = "http" end
+local port = os.getenv("ES_TEST_PORT")
+if port == nil then port = 9200 end
+local username = os.getenv("ES_USERNAME")
+local password = os.getenv("ES_PASSWORD")
+
+local client  = elasticsearch.client{
+   hosts = {
+      { -- Ignoring any of the following hosts parameters is allowed.
+        -- The default shall be set
+        protocol = protocol,
+        host = localhost,
+        port = port,
+        username = username,
+        password = password
+      }
+   }
+}
+
+-- Defining test index and type
+local TEST_INDEX = "elasticsearch-lua-test-index"
+local REINDEX_INDEX1 = "elasticsearch-lua-reindex-index-1"
+local REINDEX_INDEX2 = "elasticsearch-lua-reindex-index-2"
+
+function setup.init()
+   local res, err = client.indices:create{
+      index = TEST_INDEX
+   }
+      
+   res, status = client.indices:create{
+      index = REINDEX_INDEX1
+   }
+
+   res, status = client.indices:create{
+      index = REINDEX_INDEX2
+   }
+
+   res, status = client.indices:putSettings{
+      index = _all,
+      body = {
+         index = {
+            mapping = {
+               total_fields = {
+                  limit = 10000
+               }
+            }
+         }
+      }
+   }
+end
+
+return setup;


### PR DESCRIPTION
This PR has two main aims:
1) Including the elasticsearch setup in Lua makes the tests self-contained. Previously many tests in the test suite would fail if a separate script that modified a bunch of index settings was not run. There was no reason for these not to be run from within the Lua code itself, making the test-suite no longer reliant on an external script to be run first.
2) Fixing issues with GH Actions tests failing because it was unhappy with running 3 separate elasticsearch container simultaneously. I think it was causing swapping in the runner or similar, which caused the initial setup to fail, this the rest of the tests would then also go on to fail. This PR ensures that only the container required by the matrix is actually run.