### PR TITLE
[BUG] The issue that type is not supported for updates above Elasticsearch 7 is fixed.

### DIFF
--- a/src/elasticsearch/endpoints/Update.lua
+++ b/src/elasticsearch/endpoints/Update.lua
@@ -51,10 +51,17 @@ function Update:getUri()
   if self.index == nil then
     return nil, "index not specified for Update"
   end
-  if self.type == nil then
+
+  -- fix es since 7+ don't support type.
+  -- removes if
+
+  --[[if self.type == nil then
     return nil, "type not specified for Update"
-  end
-  return "/" .. self.index .. "/" .. self.type .. "/" .. self.id .. "/_update"
+  end]]
+
+  -- update uri
+  -- es : https://www.elastic.co/guide/en/elasticsearch/reference/7.0/docs-update.html#docs-update
+  return "/" .. self.index .. "/_update/" .. self.id
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The issue that type is not supported for updates above Elasticsearch 7 is fixed.

Elasticsearch 7+ are remove support for types, I've tested this change and it's working fine.